### PR TITLE
Use grequests to make script faster, sort list alphabetically, reduce lines of code

### DIFF
--- a/chitragupta.py
+++ b/chitragupta.py
@@ -5,7 +5,8 @@ Author : Rameshwar Bhaskaran
 
 import requests
 import json
-import pywikibot
+#  import pywikibot
+import grequests
 
 ignored_repos = set({'git-exercise'})
 
@@ -13,38 +14,33 @@ def get_all_repos():
     # get a list of all repositories in the MetaKGP org
     r = requests.get("https://api.github.com/orgs/metakgp/repos")
 
+    all_contribs = set()
+
     if not r.ok:
         print "Looks like something is wrong"
         print r.status_code
         exit(0)
     else:
         repos = json.loads(r.text)
-        contributor_urls = {}
-        for repo in repos:
-            if repo['name'] not in ignored_repos:
-                contributor_urls[repo['name']] = repo['contributors_url']
-        contributors = {}
-        for repo, url in contributor_urls.items():
-            try:
-                print "Getting ", repo
-                # ignore the sandbox
-                contributor_response = requests.get(url)
-                contributors[repo] = set()
-                repo_contributors = json.loads(contributor_response.text)
-                for contributor in repo_contributors:
-                    contributors[repo].add(contributor['login'])
-            except Exception as e:
-                print "Failed due to ", str(e)
-                pass
+        repos = repos[:20]
 
-    consolidated_list = set()
-    for repo in contributors:
-        print repo, contributors[repo]
-        consolidated_list = consolidated_list.union(contributors[repo])
-    return contributors, consolidated_list
+        contrib_urls = [repo['contributors_url'] for repo in repos if repo['name'] not in ignored_repos]
+
+        all_reqs = (grequests.get(u) for u in contrib_urls)
+
+        all_resps = grequests.map(all_reqs)
+
+        for resp in all_resps:
+            if resp:
+                repo_contribs = json.loads(resp.text)
+                all_contribs = all_contribs.union([person['login'] for person in repo_contribs])
+
+        print all_contribs
+
+    return all_contribs
 
 def main():
-    contributors, consolidated_list = get_all_repos()
+    consolidated_list = get_all_repos()
 
     # Build the markup for the page
     text = "<b>List of contributors on Github:</b><br/><br/>"
@@ -56,12 +52,16 @@ def main():
         url = "https://github.com/%s" % github_username
         text += "%s. [%s %s] <br>" % (iter + 1, url, github_username)
 
+    filout = open('test.html', 'w')
+    filout.write(text)
+    filout.close()
+
     # Update the page with this markup
 
-    site = pywikibot.Site()
-    page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
-    page.text = text
-    page.save(u'Update list of contributors')
+    #  site = pywikibot.Site()
+    #  page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
+    #  page.text = text
+    #  page.save(u'Update list of contributors')
 
 if __name__ == "__main__":
     main()

--- a/chitragupta.py
+++ b/chitragupta.py
@@ -1,6 +1,9 @@
-""" Chitragupta - The guy who tracks your contributions to the MetaKGP Github organisation!
+""" 
+Chitragupta
 
-Author : Rameshwar Bhaskaran
+> The guy who tracks your contributions to the MetaKGP Github organisation!
+
+Author: Rameshwar Bhaskaran
 """
 
 import requests
@@ -29,10 +32,13 @@ def get_all_repos():
 
         all_resps = grequests.map(all_reqs)
 
-        for resp in all_resps:
-            if resp:
+        for index, resp in enumerate(all_resps):
+            if resp and resp.status_code == 200:
                 repo_contribs = json.loads(resp.text)
                 all_contribs = all_contribs.union([person['login'] for person in repo_contribs])
+            else:
+                print "Request to %s failed. Status code: %s" % \
+                (contrib_urls[index], resp.status_code if resp else None)
 
         print all_contribs
 

--- a/chitragupta.py
+++ b/chitragupta.py
@@ -45,12 +45,21 @@ def get_all_repos():
 
 def main():
     contributors, consolidated_list = get_all_repos()
-    site = pywikibot.Site()
-    page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
+
+    # Build the markup for the page
     text = "<b>List of contributors on Github:</b><br/><br/>"
+
+    consolidated_list = list(consolidated_list)
+    consolidated_list.sort()
+
     for iter, github_username in enumerate(consolidated_list):
         url = "https://github.com/%s" % github_username
-        text += "%s. [%s %s] <br>" % (iter, url, github_username)
+        text += "%s. [%s %s] <br>" % (iter + 1, url, github_username)
+
+    # Update the page with this markup
+
+    site = pywikibot.Site()
+    page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
     page.text = text
     page.save(u'Update list of contributors')
 

--- a/chitragupta.py
+++ b/chitragupta.py
@@ -39,12 +39,12 @@ def get_all_repos():
     return all_contribs
 
 def main():
-    consolidated_list = get_all_repos()
+    consolidated_set = get_all_repos()
 
     # Build the markup for the page
     text = "<b>List of contributors on Github:</b><br/><br/>"
 
-    consolidated_list = list(consolidated_list)
+    consolidated_list = list(consolidated_set)
     consolidated_list.sort()
 
     for iter, github_username in enumerate(consolidated_list):

--- a/chitragupta.py
+++ b/chitragupta.py
@@ -5,7 +5,7 @@ Author : Rameshwar Bhaskaran
 
 import requests
 import json
-#  import pywikibot
+import pywikibot
 import grequests
 
 ignored_repos = set({'git-exercise'})
@@ -22,7 +22,6 @@ def get_all_repos():
         exit(0)
     else:
         repos = json.loads(r.text)
-        repos = repos[:20]
 
         contrib_urls = [repo['contributors_url'] for repo in repos if repo['name'] not in ignored_repos]
 
@@ -52,16 +51,12 @@ def main():
         url = "https://github.com/%s" % github_username
         text += "%s. [%s %s] <br>" % (iter + 1, url, github_username)
 
-    filout = open('test.html', 'w')
-    filout.write(text)
-    filout.close()
-
     # Update the page with this markup
 
-    #  site = pywikibot.Site()
-    #  page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
-    #  page.text = text
-    #  page.save(u'Update list of contributors')
+    site = pywikibot.Site()
+    page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
+    page.text = text
+    page.save(u'Update list of contributors')
 
 if __name__ == "__main__":
     main()

--- a/chitragupta.py
+++ b/chitragupta.py
@@ -48,11 +48,9 @@ def main():
     site = pywikibot.Site()
     page = pywikibot.Page(site, u'MetaKGP_Github_Contributors')
     text = "<b>List of contributors on Github:</b><br/><br/>"
-    i = 1
-    for name in consolidated_list:
-        url = "https://github.com/"+name
-        text += str(i)+". ["+url+" "+name+"] <br/>"
-        i += 1
+    for iter, github_username in enumerate(consolidated_list):
+        url = "https://github.com/%s" % github_username
+        text += "%s. [%s %s] <br>" % (iter, url, github_username)
     page.text = text
     page.save(u'Update list of contributors')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+grequests>=0.3.0
+pywikibot>=3.0.20170801


### PR DESCRIPTION
I ran the script for the first 20 repositories, with and without grequests. [grequests](https://github.com/kennethreitz/grequests) makes all the requests at the same time, hence reducing the time it takes to complete everything.

Before grequests:

![screenshot from 2017-09-11 23-47-25](https://user-images.githubusercontent.com/3668034/30290405-c50172b4-971e-11e7-8943-1c42844c7ad1.png)

After grequests:

![screenshot from 2017-09-11 23-47-54](https://user-images.githubusercontent.com/3668034/30290411-ca49686c-971e-11e7-931e-ca60b5968a2d.png)

That's a nearly threefold improvement.

Also, a lot of the code can be succinctly written with map / filter and such.

There was also a bit more work inside the function earlier than necessary (such as repo-wise contributor list, which we are not using anywhere.) So I have removed all that and just directly created the set of contributors.

cc @zorroblue @ghostwriternr @arunpatro 